### PR TITLE
feat(ai): skills for opencode and codex

### DIFF
--- a/modules/aspects/cli/ai.nix
+++ b/modules/aspects/cli/ai.nix
@@ -34,7 +34,7 @@
         mattPocockSkills = lib.listToAttrs (
           map (skillFile: {
             name = builtins.unsafeDiscardStringContext (baseNameOf (dirOf (toString skillFile)));
-            value.source = dirOf (toString skillFile);
+            value = dirOf (toString skillFile);
           }) skillFiles
         );
       in
@@ -45,10 +45,14 @@
         };
 
         programs = {
-          codex.enable = true;
+          codex = {
+            enable = true;
+            skills = mattPocockSkills;
+          };
 
           opencode = {
             enable = true;
+            skills = mattPocockSkills;
             settings = {
               permission = {
                 "*" = {
@@ -81,11 +85,6 @@
 
           t3code.enable = true;
         };
-
-        xdg.configFile = lib.mapAttrs' (name: value: {
-          name = "codex/skills/${name}";
-          inherit value;
-        }) mattPocockSkills;
 
         systemd.user.services.t3code-web = {
           Unit = {


### PR DESCRIPTION
## Summary
- Moved `mattPocockSkills` wiring into `programs.codex.skills` and `programs.opencode.skills`.
- Simplified the aspect by removing the separate `xdg.configFile` symlink setup for Codex skills.
- Kept the skill source map generation in one place for both CLIs.

## Testing
- Not run (config-only change).
- Reviewed the updated Nix module shape in `modules/aspects/cli/ai.nix` for `programs.*.skills` usage.