### PR TITLE
feat(cli): replace tmux with zellij

### DIFF
--- a/modules/aspects/cli/shell.nix
+++ b/modules/aspects/cli/shell.nix
@@ -46,7 +46,7 @@
             ];
             interactiveShellInit = ''
               if not set -q ZELLIJ; and set -q SSH_TTY
-                zellij attach ssh --create
+                zellij attach --create ssh
               end
 
               set -g fish_key_bindings fish_vi_key_bindings

--- a/modules/aspects/cli/shell.nix
+++ b/modules/aspects/cli/shell.nix
@@ -45,8 +45,8 @@
               }
             ];
             interactiveShellInit = ''
-              if not set -q TMUX; and set -q SSH_TTY
-                tmux new-session -A -s ssh
+              if not set -q ZELLIJ; and set -q SSH_TTY
+                zellij attach ssh --create
               end
 
               set -g fish_key_bindings fish_vi_key_bindings

--- a/modules/aspects/cli/zellij.nix
+++ b/modules/aspects/cli/zellij.nix
@@ -1,0 +1,23 @@
+{ den, ... }:
+{
+  den.aspects.zellij = {
+    includes = [ ];
+
+    homeManager =
+      { ... }:
+      {
+        programs.zellij = {
+          enable = true;
+          settings = {
+            scroll_buffer_size = 10000;
+            mouse_mode = true;
+            session_serialization = true;
+            serialize_pane_viewport = true;
+            scrollback_lines_to_serialize = 10000;
+            show_startup_tips = false;
+            show_release_notes = false;
+          };
+        };
+      };
+  };
+}

--- a/modules/aspects/repparw.nix
+++ b/modules/aspects/repparw.nix
@@ -19,7 +19,7 @@
       (den.batteries.user-shell "fish")
       den.batteries.host-aspects
       den.aspects.shell
-      den.aspects.tmux
+      den.aspects.zellij
       den.aspects.git
       den.aspects.ai
       den.aspects.ssh


### PR DESCRIPTION
## Summary
- add a Home Manager-backed Zellij aspect
- switch the `repparw` profile from `den.aspects.tmux` to `den.aspects.zellij`
- replace SSH tmux auto-attach with `zellij attach ssh --create`

## Notes
- keeps auto-attach limited to SSH shells instead of enabling Zellij globally for every local terminal
- enables Zellij session serialization and viewport serialization to cover the main tmux-resurrect/continuum use case
- leaves the existing tmux aspect available but no longer included in the `repparw` profile

## Testing
- Not run; change created through GitHub connector only.