### PR TITLE
Track upstream package and module cleanups

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -455,11 +455,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1785454630,
-        "narHash": "sha256-LQy14TZp77TwbQf40gg1V3jo8FwJG0jGDkAH+zRHqg8=",
+        "lastModified": 1785571196,
+        "narHash": "sha256-KoTsyMQqnXQZq8deCEnu4QkyldkwH/bpMMhUcfMdGIw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1559d3daa3ecc813a650b79375ea61b6741b8746",
+        "rev": "148bab9c1c3c53136ecb44a6ea356a0ed5b39b06",
         "type": "github"
       },
       "original": {

--- a/modules/aspects/ai/default.nix
+++ b/modules/aspects/ai/default.nix
@@ -143,6 +143,9 @@
           t3code.enable = true;
         };
 
+        # TODO: Replace this hand-rolled service with programs.t3code.server
+        # once https://github.com/nix-community/home-manager/pull/9695 merges
+        # and reaches our pinned input.
         systemd.user.services.t3code-web = {
           Unit = {
             Description = "T3 Code Web Service";

--- a/modules/aspects/ai/dictation.nix
+++ b/modules/aspects/ai/dictation.nix
@@ -15,9 +15,10 @@
         ...
       }:
       let
-        system = pkgs.stdenv.hostPlatform.system;
         voxtypeSource = inputs.voxtype;
-        voxtypePackage = voxtypeSource.packages.${system}.vulkan;
+        # The external input remains for its HM module and QML source. The
+        # package is already available upstream at the same v0.7.5 version.
+        voxtypePackage = pkgs.voxtype-vulkan;
         voxtypeQuickshell = pkgs.runCommand "voxtype-quickshell-themed" { } ''
           cp -R ${voxtypeSource}/quickshell $out
           chmod -R u+w $out
@@ -104,6 +105,8 @@
         };
       in
       {
+        # TODO: Upstream this Home Manager module. No open Voxtype PR exists
+        # in nix-community/home-manager yet.
         imports = [ inputs.voxtype.homeManagerModules.default ];
 
         home.packages = [

--- a/modules/aspects/gui/apps.nix
+++ b/modules/aspects/gui/apps.nix
@@ -4,6 +4,8 @@
   ...
 }:
 let
+  # TODO: Remove this patch and use pkgs.tasks-org once
+  # https://github.com/NixOS/nixpkgs/pull/518221 lands in our pin.
   tasksOrgNixpkgs =
     pkgs:
     pkgs.applyPatches {

--- a/modules/aspects/services/arr.nix
+++ b/modules/aspects/services/arr.nix
@@ -148,6 +148,8 @@
               nixpkgs.overlays = [
                 (final: prev: {
                   qbittorrent-nox = prev.qbittorrent-nox.overrideAttrs (old: {
+                    # TODO: Remove this patch once qBittorrent PR #24055 lands
+                    # in a release covered by Nixpkgs.
                     patches = (old.patches or [ ]) ++ [
                       (prev.fetchpatch {
                         url = "https://patch-diff.githubusercontent.com/raw/qbittorrent/qBittorrent/pull/24055.patch";

--- a/modules/aspects/streaming/default.nix
+++ b/modules/aspects/streaming/default.nix
@@ -5,9 +5,8 @@
   ...
 }:
 {
-  # TODO: Replace the upstream package after the Nixpkgs update reaches the
-  # currently used 0.14.1 and lands in our pin:
-  # https://github.com/NixOS/nixpkgs/pull/546531
+  # Nixpkgs now provides Moonshine 0.13.5. Keep this input for the external
+  # NixOS module until https://github.com/NixOS/nixpkgs/pull/544393 lands.
   flake-file.inputs.moonshine = {
     url = "github:hgaiser/moonshine";
     inputs.nixpkgs.follows = "nixpkgs";
@@ -90,8 +89,9 @@
       };
     in
     {
-      # TODO: Drop this flake import and use the Nixpkgs module once the draft
-      # PR lands in our pin: https://github.com/NixOS/nixpkgs/pull/544393
+      # The upstream module uses `firewallInterfaces` instead of
+      # `openFirewall` and does not expose `uid`; adapt this service block when
+      # https://github.com/NixOS/nixpkgs/pull/544393 lands in our pin.
       imports = [ inputs.moonshine.nixosModules.default ];
 
       options.modules.streaming.shellApplications = lib.mkOption {
@@ -110,6 +110,7 @@
           inherit user;
           uid = 1000;
           openFirewall = true;
+          package = pkgs.moonshine;
 
           settings = {
             name = config.networking.hostName;


### PR DESCRIPTION
## What changed

- Update the locked Nixpkgs input to the current `nixos-unstable` revision.
- Use upstream `pkgs.voxtype-vulkan` at 0.7.5.
- Use upstream `pkgs.moonshine` at 0.13.5.
- Add TODO markers for the remaining upstream-dependent removals.

## Blockers tracked

- [#23 tasks.org patch cleanup](https://github.com/repparw/nix/issues/23)
- [#24 Moonshine module migration](https://github.com/repparw/nix/issues/24)
- [#25 T3 Code service migration](https://github.com/repparw/nix/issues/25)
- [#26 qBittorrent patch cleanup](https://github.com/repparw/nix/issues/26)
- [#27 Voxtype Home Manager module](https://github.com/repparw/nix/issues/27)

## Why draft

The package migrations are valid now. The external Moonshine and Voxtype inputs remain because their Home Manager/NixOS modules are not yet available in the pinned upstream inputs.

## Validation

- `git diff --check`
- Nix evaluation of the resolved Moonshine and Voxtype package names
- Alpha host evaluation of both package options