### PR TITLE
Use the Home Manager T3 Code server module

### DIFF
--- a/modules/aspects/ai/default.nix
+++ b/modules/aspects/ai/default.nix
@@ -143,22 +143,19 @@
           t3code.enable = true;
         };
 
-        systemd.user.services.t3code-web = {
-          Unit = {
-            Description = "T3 Code Web Service";
-            After = [ "network.target" ];
-          };
-          Service = {
-            ExecStart = "${pkgs.t3code}/bin/t3 serve --host 0.0.0.0 --port 4097 --mode web";
-            Restart = "always";
-            RestartSec = 5;
-            Environment = [
-              "T3CODE_DISABLE_PROVIDER_UPDATE_NOTIFICATIONS=1"
-            ];
-          };
-          Install = {
-            WantedBy = [ "default.target" ];
-          };
+        programs.t3code.server = {
+          enable = true;
+          extraArgs = [
+            "--host"
+            "0.0.0.0"
+            "--port"
+            "4097"
+            "--mode"
+            "web"
+          ];
+          environmentFile = pkgs.writeText "t3code-server-environment" ''
+            T3CODE_DISABLE_PROVIDER_UPDATE_NOTIFICATIONS=1
+          '';
         };
 
         systemd.user.services.codex-desktop = {


### PR DESCRIPTION
## Summary

Replace the hand-rolled `systemd.user.services.t3code-web` unit with `programs.t3code.server`.

The draft preserves:
- host `0.0.0.0`
- port `4097`
- web mode
- provider-notification suppression

## Upstream blocker

Keep this draft until [Home Manager #9695](https://github.com/nix-community/home-manager/pull/9695) is merged and the module is available in the pinned Home Manager input.

After that lands: update the flake lock, merge this PR, and rebuild.

Tracked by [nix issue #25](https://github.com/repparw/nix/issues/25).

## Validation

- Nix syntax parse
- `git diff --check`