### PR TITLE
Remove the qBittorrent free-space patch

### DIFF
--- a/modules/aspects/services/arr.nix
+++ b/modules/aspects/services/arr.nix
@@ -145,18 +145,6 @@
           qbittorrent = {
             mediaBind = false;
             extraConfig = {
-              nixpkgs.overlays = [
-                (final: prev: {
-                  qbittorrent-nox = prev.qbittorrent-nox.overrideAttrs (old: {
-                    patches = (old.patches or [ ]) ++ [
-                      (prev.fetchpatch {
-                        url = "https://patch-diff.githubusercontent.com/raw/qbittorrent/qBittorrent/pull/24055.patch";
-                        hash = "sha256-XW4ZnyaxBuIb3kny12+T/uTQOFIOVnBRV9qc1AWy6MY=";
-                      })
-                    ];
-                  });
-                })
-              ];
               services.qbittorrent.group = "media";
               users.groups.media.gid = 900;
               systemd.services.qbittorrent.preStart = lib.mkBefore ''


### PR DESCRIPTION
## Summary

Remove the local qBittorrent overlay and PR patch. Host-specific qBittorrent group, lockfile, umask, and firewall configuration remain unchanged.

## Upstream blocker

Keep this draft until [qBittorrent #24055](https://github.com/qbittorrent/qBittorrent/pull/24055) is merged, released, and included in Nixpkgs.

After that lands: update the flake lock, verify the feature is present in the package, merge this PR, and rebuild.

Tracked by [nix issue #26](https://github.com/repparw/nix/issues/26).

## Validation

- Nix syntax parse
- `git diff --check`