### PR TITLE
Use the upstream Moonshine NixOS module

### DIFF
--- a/modules/aspects/streaming.nix
+++ b/modules/aspects/streaming.nix
@@ -3,12 +3,6 @@
   lib,
   ...
 }:
-let
-  moonshineModule = builtins.fetchurl {
-    url = "https://raw.githubusercontent.com/NixOS/nixpkgs/1fa7b5d1a5463a1be4132fcff190fb20919e4d45/nixos/modules/services/networking/moonshine.nix";
-    sha256 = "sha256-nanahbt+fzl4iD+2xxTVZ0Cagk4kSwLMRmFyD7xRtdw=";
-  };
-in
 {
   den.aspects.streaming.nixos =
     {
@@ -144,8 +138,9 @@ in
       };
     in
     {
-      imports = [ moonshineModule ];
-
+      # services.moonshine options come from the Nixpkgs module (nixpkgs PR
+      # 544393) instead of the fetched commit; the fetch is dropped once that
+      # PR merges and reaches our nixpkgs pin.
       options.modules.streaming.shellApplications = lib.mkOption {
         type = lib.types.attrsOf lib.types.package;
         default = { };


### PR DESCRIPTION
Step 2 of 2 (stacked on #37).

Use the Nixpkgs `services.moonshine` module instead of the external
`builtins.fetchurl` module (which #37 keeps, since the module PR is still open).

- removes the `builtins.fetchurl` moonshine module
- `services.moonshine` options now come from Nixpkgs (nixpkgs PR 544393)
- package from `pkgs.moonshine` (inherited from #37)

## Upstream blocker

Keep this draft until Nixpkgs #544393 (module init) lands and the pinned
nixpkgs input is bumped. Then merge this PR.

Tracked by nix issue #24.