### PR TITLE
Remove the patched tasks.org package

### DIFF
--- a/modules/aspects/gui/apps.nix
+++ b/modules/aspects/gui/apps.nix
@@ -1,22 +1,7 @@
 {
   den,
-  inputs,
   ...
 }:
-let
-  tasksOrgNixpkgs =
-    pkgs:
-    pkgs.applyPatches {
-      name = "nixpkgs-tasks-org-patched";
-      src = inputs.nixpkgs;
-      patches = [
-        (pkgs.fetchpatch {
-          url = "https://github.com/NixOS/nixpkgs/pull/518221.patch";
-          hash = "sha256-VM4zx9pcyHgRFZiM6ga9uen3txKCFJAJ0lNISQswcI8=";
-        })
-      ];
-    };
-in
 {
   flake-file.inputs.nixcord = {
     url = "github:FlameFlag/nixcord";
@@ -27,19 +12,6 @@ in
       { pkgs, ... }:
       {
         nixpkgs.overlays = [
-          (final: prev: {
-            tasks-org =
-              (final.callPackage (tasksOrgNixpkgs final + "/pkgs/by-name/ta/tasks-org/package.nix") { })
-              .overrideAttrs
-                (_: {
-                  postFixup = ''
-                    wrapProgram $out/bin/tasks-org \
-                      --prefix LD_LIBRARY_PATH : "$out/lib/runtime/lib:$out/lib/runtime/lib/server:${
-                        final.lib.makeLibraryPath [ final.dbus ]
-                      }"
-                  '';
-                });
-          })
           (final: prev: {
             wshowkeys = prev.wshowkeys.overrideAttrs (old: {
               src = prev.fetchFromGitHub {


### PR DESCRIPTION
## Summary

Remove the local patched Nixpkgs tree and tasks.org overlay so the configuration uses `pkgs.tasks-org`.

## Upstream blocker

Keep this draft until [Nixpkgs #518221](https://github.com/NixOS/nixpkgs/pull/518221) is merged and the package is available in the pinned Nixpkgs input.

After that lands: update the flake lock, merge this PR, and rebuild.

Tracked by [nix issue #23](https://github.com/repparw/nix/issues/23).

## Validation

- Nix syntax parse
- `git diff --check`