### PR TITLE
Use the Nixpkgs Moonshine package (0.15.0)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -322,24 +322,6 @@
         "type": "github"
       }
     },
-    "moonshine": {
-      "inputs": {
-        "nixpkgs": "nixpkgs"
-      },
-      "locked": {
-        "lastModified": 1786969701,
-        "narHash": "sha256-LpkXi0pO8JSDCaMwpoWDzmxz7Q5wZgXzD64FllYzmPg=",
-        "owner": "hgaiser",
-        "repo": "moonshine",
-        "rev": "6ce84861613e6313be02583ba624b1117f6626f0",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hgaiser",
-        "repo": "moonshine",
-        "type": "github"
-      }
-    },
     "nix-index-database": {
       "inputs": {
         "nixpkgs": [
@@ -363,7 +345,7 @@
     "nixcord": {
       "inputs": {
         "flake-parts": "flake-parts_2",
-        "nixpkgs": "nixpkgs_2",
+        "nixpkgs": "nixpkgs",
         "nixpkgs-nixcord": "nixpkgs-nixcord",
         "treefmt-nix": "treefmt-nix"
       },
@@ -383,16 +365,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1784497964,
-        "narHash": "sha256-vlHUuqAcbcH2RKmHbPiuQzbv1pnzzavXnI62RD0bqCU=",
+        "lastModified": 1786711500,
+        "narHash": "sha256-QvnceIGTBeDvDd9oCn+GvdsnkquliuwbVgpiRH68qaQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "241313f4e8e508cb9b13278c2b0fa25b9ca27163",
+        "rev": "02e08985a27c65ffd33d434eeb2e660a2e4dc84d",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-unstable",
+        "ref": "nixos-26.05",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -429,22 +411,6 @@
       }
     },
     "nixpkgs_2": {
-      "locked": {
-        "lastModified": 1786711500,
-        "narHash": "sha256-QvnceIGTBeDvDd9oCn+GvdsnkquliuwbVgpiRH68qaQ=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "02e08985a27c65ffd33d434eeb2e660a2e4dc84d",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-26.05",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_3": {
       "locked": {
         "lastModified": 1786862985,
         "narHash": "sha256-FBJRXmbGXiSUDvYEbfLYRkckayyZ6SK1UEqhCrIZ2Cs=",
@@ -548,10 +514,9 @@
         "helium-nix": "helium-nix",
         "home-manager": "home-manager",
         "import-tree": "import-tree",
-        "moonshine": "moonshine",
         "nix-index-database": "nix-index-database",
         "nixcord": "nixcord",
-        "nixpkgs": "nixpkgs_3",
+        "nixpkgs": "nixpkgs_2",
         "nixvim": "nixvim",
         "nixvim-config": "nixvim-config",
         "sops-nix": "sops-nix",

--- a/flake.nix
+++ b/flake.nix
@@ -34,7 +34,6 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
     import-tree.url = "github:vic/import-tree";
-    moonshine.url = "github:hgaiser/moonshine";
     nix-index-database = {
       url = "github:nix-community/nix-index-database";
       inputs.nixpkgs.follows = "nixpkgs";

--- a/modules/aspects/streaming.nix
+++ b/modules/aspects/streaming.nix
@@ -1,22 +1,15 @@
 {
   den,
-  inputs,
   lib,
   ...
 }:
 let
   moonshineModule = builtins.fetchurl {
-    url = "https://raw.githubusercontent.com/NixOS/nixpkgs/refs/pull/544393/head/nixos/modules/services/networking/moonshine.nix";
-    sha256 = "sha256-YEKjwB8/JxFQ3cFXTOCxMGp8Vg+KNk6JiwLqN3iOFbk=";
+    url = "https://raw.githubusercontent.com/NixOS/nixpkgs/1fa7b5d1a5463a1be4132fcff190fb20919e4d45/nixos/modules/services/networking/moonshine.nix";
+    sha256 = "sha256-nanahbt+fzl4iD+2xxTVZ0Cagk4kSwLMRmFyD7xRtdw=";
   };
 in
 {
-  # Latest upstream build (nixpkgs ships 0.13.5, upstream is 0.15.0). Declared
-  # here so write-flake keeps it in flake.nix inputs.
-  flake-file.inputs.moonshine = {
-    url = "github:hgaiser/moonshine";
-  };
-
   den.aspects.streaming.nixos =
     {
       config,
@@ -173,8 +166,7 @@ in
           enable = true;
           inherit user;
           firewallInterfaces = [ "eth0" ];
-          # Latest upstream git build (nixpkgs ships 0.13.5, upstream is 0.15.0).
-          package = inputs.moonshine.packages.${pkgs.stdenv.hostPlatform.system}.moonshine;
+          package = pkgs.moonshine;
 
           settings = {
             name = config.networking.hostName;


### PR DESCRIPTION
Drop the upstream moonshine flake input and use pkgs.moonshine now that nixpkgs ships 0.15.0 (nixpkgs PR 546531, merged 2026-08-14).

- package = pkgs.moonshine
- drop flake-file.inputs.moonshine (write-flake removes it from flake.nix)
- keep the services.moonshine module fetched from nixpkgs PR 544393 (still open); pin the fetch to immutable commit 1fa7b5d1 instead of the moving PR head, with refreshed content hash

Stacked as the base; the module PR (#31) stacks on top.