### PR TITLE
feat(pi): add NixOS migration config for Raspberry Pi 5

### DIFF
--- a/.sops.yaml
+++ b/.sops.yaml
@@ -2,4 +2,5 @@ creation_rules:
   - path_regex: secrets/(archisteamfarm|authelia|automations|backup|ddclient|jellyfin|matriz|nix|proxy|rclone|streaming)\.sops\.yaml
     age: >-
       age19wxpznth9v4qc46lzzvall6xmazexykkz59ax6w0n4nrgpkcrassld7n3v,
-      age1jsdf5x72y30aq0ghpuwyn9nv6w7m2jgh3f309kpqaf0jw0d4mgrscefqfp
+      age1jsdf5x72y30aq0ghpuwyn9nv6w7m2jgh3f309kpqaf0jw0d4mgrscefqfp,
+      age1x7qu0en7rg0qm6rq5dfvyn3w34se2qt6wdw7yzgtwjkgj3skssgqmeut5m

--- a/docs/hosts.md
+++ b/docs/hosts.md
@@ -34,7 +34,9 @@ aspect (headless: no desktop/GUI stack).
 
 It boots `linuxPackages_latest` through the Raspberry Pi firmware and
 generic-extlinux-compatible loader, with the user home on the NVMe volume and
-activation via the repo flake.
+activation via the repo flake. The SD card layout (GPT, pinned partition GUIDs,
+u-boot + config.txt firmware) is managed by disko; see the
+[deployment runbook](runbooks/deploy-pi-nixos.md).
 
 Source: `modules/hosts/pi.nix`
 

--- a/docs/hosts.md
+++ b/docs/hosts.md
@@ -1,14 +1,14 @@
 ---
 type: Host Profiles
 title: Host Profiles
-description: The alpha desktop and beta laptop profiles.
+description: The alpha desktop, beta laptop, and pi server profiles.
 resource: modules/hosts/
-tags: [hosts, alpha, beta]
+tags: [hosts, alpha, beta, pi]
 ---
 
 # Host Profiles
 
-Both hosts share the baseline in `modules/defaults.nix` and add hardware or
+The hosts share the baseline in `modules/defaults.nix` and add hardware or
 workload-specific aspects in `modules/hosts/`.
 
 ## Alpha
@@ -24,6 +24,19 @@ Source: `modules/hosts/alpha.nix`
 handling to the shared baseline.
 
 Source: `modules/hosts/beta.nix`
+
+## Pi
+
+`pi` is the Raspberry Pi 5 home server (aarch64, `192.168.0.4`). It runs the
+home-automation LAN DNS server on systemd-resolved, ssh/mosh access, and the
+Home Assistant pod as a rootless podman kube service via the `pi-repparw` user
+aspect (headless: no desktop/GUI stack).
+
+It boots `linuxPackages_latest` through the Raspberry Pi firmware and
+generic-extlinux-compatible loader, with the user home on the NVMe volume and
+activation via the repo flake.
+
+Source: `modules/hosts/pi.nix`
 
 ## Related
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,10 +29,11 @@ files instead of copying module contents.
 ## Runbooks
 
 - [Add and maintain change-detection watchers](runbooks/change-detection-watchers.md)
+- [Check native container DNS](runbooks/check-native-container-dns.md)
+- [Deploy NixOS to the Raspberry Pi](runbooks/deploy-pi-nixos.md)
 - [Failed auto-upgrade rollback](runbooks/failed-auto-upgrade-rollback.md)
 - [Obsidian rclone bisync](runbooks/obsidian-rclone-bisync.md)
 - [Restore service backups](runbooks/restore-service-backups.md)
-- [Check native container DNS](runbooks/check-native-container-dns.md)
 
 ## Research
 

--- a/docs/runbooks/deploy-pi-nixos.md
+++ b/docs/runbooks/deploy-pi-nixos.md
@@ -1,0 +1,87 @@
+---
+type: Runbook
+title: Deploy NixOS to the Raspberry Pi (migration)
+description: Install NixOS on the pi's SD card via nixos-anywhere, keeping the NVMe home disk and the Debian SSH host key.
+when: Read when migrating the Raspberry Pi 5 from Debian to NixOS or reinstalling it.
+resource: modules/hosts/pi.nix
+tags: [runbook, pi, migration, nixos-anywhere, disko]
+---
+
+# Deploy NixOS to the Raspberry Pi
+
+The pi boots NixOS from the SD card (`/dev/mmcblk0`). The NVMe
+(`/dev/nvme0n1`) holds `/home/repparw` and is deliberately **not** part of the
+disko config, so it is never touched by the installer. The SD layout is GPT
+with pinned partition GUIDs, referenced from `fileSystems` in
+`modules/hosts/pi.nix`.
+
+## Prerequisites
+
+1. Backups (run beforehand, kept in `~/backups/pi/`):
+   - SD image: `pi-sd-2026-08-18.img`
+   - NVMe state: `nvme-state-2026-08-18.tar.gz`
+   - SSH host key: `ssh_host_ed25519_key.pi` / `ssh_host_ed25519_key.pub.pi`
+2. The Debian host key must be copied into the new root before first boot:
+   sops decrypts via `/etc/ssh/ssh_host_ed25519_key`, and the pi's sops
+   recipient is derived from that exact key. Without it, `setupSecrets` fails
+   and the first `nixos-rebuild` aborts.
+3. A NixOS **aarch64 installer** must be booted manually first (USB stick or
+   second SD): kexec does not work on the pi (its kernel has no
+   `CONFIG_KEXEC_FILE`), so nixos-anywhere runs with `--phases
+   disko,install,reboot`, skipping `kexec`.
+4. alpha cannot build aarch64 (no binfmt emulation), so builds happen **on the
+   installer** with `--build-on remote`.
+
+## Deploy
+
+```sh
+# 1. Boot the NixOS aarch64 installer from USB, reachable at 192.168.0.4.
+#    SSH must work (installer default: user nixos).
+
+# 2. Stage the Debian SSH host key so sops can decrypt on first boot.
+#    --extra-files copies recursively into the new root at /.
+mkdir -p /tmp/pi-extra/etc/ssh
+cp ~/backups/pi/ssh_host_ed25519_key.pi /tmp/pi-extra/etc/ssh/ssh_host_ed25519_key
+cp ~/backups/pi/ssh_host_ed25519_key.pub.pi /tmp/pi-extra/etc/ssh/ssh_host_ed25519_key.pub
+
+# 3. Install (run from the repo root on alpha).
+nix run github:nix-community/nixos-anywhere -- \
+  --flake '.#pi' \
+  --target-host root@192.168.0.4 \
+  --phases disko,install,reboot \
+  --build-on remote \
+  --extra-files /tmp/pi-extra
+```
+
+Notes:
+
+- `--phases disko,install,reboot` skips `kexec` (installer already running).
+- `--build-on remote` builds the aarch64 system and disko script on the
+  installer, avoiding the need for binfmt on alpha.
+- `disko` (default mode) destroys and recreates **only** the disks listed in
+  the disko config (`/dev/mmcblk0`); `nvme0n1` stays untouched.
+- The firmware partition's `postMountHook` installs u-boot, RPi firmware
+  blobs, device trees, and `config.txt` (replicating nixpkgs'
+  `sd-image-aarch64`), so the SD boots via EEPROM → u-boot → extlinux.
+
+## First boot checks
+
+```sh
+ssh pi
+sudo nixos-rebuild switch --flake '.#pi'
+# Verify mounts, sops secrets, and the Home Assistant pod:
+findmnt /home/repparw
+sudo systemctl status sops-nix
+systemctl --user status podservices-homeassistant
+```
+
+## Restore / rollback
+
+- Full restore: `dd` the SD image back (`~/backups/pi/pi-sd-2026-08-18.img`)
+  and re-extract the NVMe tar onto `/home/repparw`.
+- The host key backup doubles as the sops key for the NixOS install.
+
+## Related
+
+- [Host profiles](../hosts.md)
+- [Secrets](../agents/issue-tracker.md#secrets)

--- a/flake.lock
+++ b/flake.lock
@@ -83,6 +83,26 @@
         "type": "github"
       }
     },
+    "disko": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1781152676,
+        "narHash": "sha256-RxWs5ND31KzTG7wvMM+PMfUjyNpmIEr999lqNARaM5o=",
+        "owner": "nix-community",
+        "repo": "disko",
+        "rev": "ff8702b4de27f72b4c78573dfb89ec74e36abdf1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "disko",
+        "type": "github"
+      }
+    },
     "firefox-addons": {
       "inputs": {
         "flake-utils": [
@@ -540,6 +560,7 @@
     "root": {
       "inputs": {
         "den": "den",
+        "disko": "disko",
         "firefox-addons": "firefox-addons",
         "flake-file": "flake-file",
         "flake-parts": "flake-parts",

--- a/flake.nix
+++ b/flake.nix
@@ -5,6 +5,10 @@
 
   inputs = {
     den.url = "github:denful/den";
+    disko = {
+      url = "github:nix-community/disko";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
     firefox-addons = {
       url = "github:petrkozorezov/firefox-addons-nix";
       inputs = {

--- a/modules/hosts/pi.nix
+++ b/modules/hosts/pi.nix
@@ -1,0 +1,280 @@
+{
+  den,
+  lib,
+  pkgs,
+  ...
+}:
+{
+  den.aspects.pi = {
+    includes = [
+      den.batteries.hostname
+      den.aspects.networking
+      den.aspects.secrets
+    ];
+
+    nixos =
+      {
+        config,
+        lib,
+        pkgs,
+        ...
+      }:
+      {
+        # Raspberry Pi 5 (aarch64) triple-boot loader: firmware (u-boot +
+        # config.txt) lives on the vfat /boot/firmware partition, while NixOS
+        # writes the extlinux boot files into /boot on the ext4 root.
+        boot = {
+          kernelPackages = pkgs.linuxPackages_latest;
+          kernelParams = [
+            "console=ttyMA0,115200n8"
+            "console=tty0"
+          ];
+          loader = {
+            grub.enable = false;
+            generic-extlinux-compatible.enable = true;
+          };
+        };
+
+        fileSystems = {
+          "/" = {
+            device = "/dev/disk/by-partuuid/b50071b8-02";
+            fsType = "ext4";
+            options = [
+              "defaults"
+              "noatime"
+            ];
+          };
+
+          "/boot/firmware" = {
+            device = "/dev/disk/by-partuuid/b50071b8-01";
+            fsType = "vfat";
+          };
+
+          # User home + Home Assistant data live on the NVMe, so the pod's
+          # ~/services/hass carries over from the Debian install unchanged.
+          "/home/repparw" = {
+            device = "/dev/disk/by-partuuid/7fd52c5b-01";
+            fsType = "ext4";
+            options = [
+              "defaults"
+              "noatime"
+            ];
+          };
+        };
+
+        swapDevices = [ ];
+
+        hardware.bluetooth.enable = true;
+
+        virtualisation.podman = {
+          enable = true;
+          autoPrune.enable = true;
+        };
+
+        nixpkgs.hostPlatform = lib.mkDefault "aarch64-linux";
+
+        # LAN DNS server: resolved listens on the LAN address and proxies to
+        # Cloudflare/Quad9 over DoT.
+        services.resolved.settings.Resolve = {
+          DNS = [
+            "1.1.1.1#cloudflare-dns.com"
+            "1.0.0.1#cloudflare-dns.com"
+          ];
+          FallbackDNS = [ "9.9.9.9#dns.quad9.net" ];
+          DNSSEC = true;
+          DNSOverTLS = true;
+          Cache = true;
+          DNSStubListenerExtra = "192.168.0.4:53";
+        };
+
+        networking = {
+          # First boot / install note: the resolver chain above only comes up
+          # once this static address is configured (systemd.network below).
+          interfaces.eth0.ipv4.addresses = [
+            {
+              address = "192.168.0.4";
+              prefixLength = 24;
+            }
+          ];
+          defaultGateway = {
+            address = "192.168.0.1";
+            interface = "eth0";
+          };
+          hosts = {
+            "192.168.0.18" = [
+              "repparw.com"
+              "code.repparw.com"
+              "auth.repparw.com"
+              "bazarr.repparw.com"
+              "broker.repparw.com"
+              "changedetection.repparw.com"
+              "ddclient.repparw.com"
+              "rss.repparw.com"
+              "jellyfin.repparw.com"
+              "mercury.repparw.com"
+              "ntfy.repparw.com"
+              "paperdb.repparw.com"
+              "paper.repparw.com"
+              "profilarr.repparw.com"
+              "prowlarr.repparw.com"
+              "qbit.repparw.com"
+              "radarr.repparw.com"
+              "seerr.repparw.com"
+              "sockpuppetbrowser.repparw.com"
+              "sonarr.repparw.com"
+              "traefik.repparw.com"
+              "valkey.repparw.com"
+              "home.repparw.com"
+            ];
+            "192.168.0.4" = [
+              "hyperion.repparw.com"
+              "pihole.repparw.com"
+            ];
+          };
+
+          firewall.interfaces.eth0 = {
+            allowedTCPPorts = [
+              80
+              53
+            ];
+            allowedUDPPorts = [
+              53
+              60001
+            ];
+          };
+        };
+      };
+  };
+
+  # Minimal headless repparw: same account as alpha but without the desktop
+  # stack. Mirrors the Debian-era setup on the pi (fish shell, ssh keys, and
+  # the rootless podman Home Assistant pod below).
+  den.aspects.pi-repparw = {
+    includes = [
+      den.batteries.define-user
+      den.batteries.primary-user
+      (den.batteries.user-shell "fish")
+      den.aspects.shell
+      den.aspects.tmux
+      den.aspects.git
+      den.aspects.ssh
+    ];
+
+    user = _: {
+      linger = true;
+      description = "repparw";
+      extraGroups = [ "wheel" ];
+      subUidRanges = [
+        {
+          startUid = 100000;
+          count = 65536;
+        }
+      ];
+      subGidRanges = [
+        {
+          startGid = 100000;
+          count = 65536;
+        }
+      ];
+    };
+
+    provides.to-hosts = {
+      nixos =
+        { ... }:
+        {
+          home-manager = {
+            useGlobalPkgs = true;
+            useUserPackages = true;
+            backupFileExtension = "hm-backup";
+          };
+        };
+    };
+
+    homeManager =
+      {
+        config,
+        lib,
+        pkgs,
+        ...
+      }:
+      {
+        xdg.enable = true;
+        home.preferXdgDirectories = true;
+
+        # Home Assistant pod: kept as a rootless podman kube manifest so the
+        # data under ~/services/hass and the container layout from the Debian
+        # installation carry over unchanged. `podman kube play --replace` is
+        # the NixOS-managed equivalent of the on-pi quadlet services.kube.
+        home.file."services/pod.yaml".text = ''
+          # Save the output of this file and use kubectl create -f to import
+          # it into Kubernetes.
+          #
+          # Created with podman-5.4.2
+
+          # NOTE: The namespace sharing for a pod has been modified by the user and is not the same as the
+          # default settings for kubernetes. This can lead to unexpected behavior when running the generated
+          # kube yaml in a kubernetes cluster.
+          ---
+          apiVersion: v1
+          kind: Pod
+          metadata:
+            annotations:
+              io.containers.autoupdate/homeassistant: registry
+              io.kubernetes.cri-o.SandboxID/homeassistant: 4bf37bb3e42a602c9ae39b84f7c1bb02525c6d9b73df1fce83680bc5454621cb
+            creationTimestamp: "2026-02-16T14:54:45Z"
+            labels:
+              app: podservices
+            name: podservices
+          spec:
+            containers:
+            - image: docker.io/homeassistant/home-assistant:stable
+              name: homeassistant
+              ports:
+              - containerPort: 8123
+                hostPort: 80
+              securityContext:
+                privileged: true
+                procMount: Unmasked
+              volumeMounts:
+              - mountPath: /config
+                name: home-repparw-services-hass-host-0
+              - mountPath: /etc/localtime
+                name: etc-localtime-host-1
+                readOnly: true
+              - mountPath: /run/dbus
+                name: run-dbus-host-2
+                readOnly: true
+            volumes:
+            - hostPath:
+                path: /home/repparw/services/hass
+                type: Directory
+              name: home-repparw-services-hass-host-0
+            - hostPath:
+                path: /etc/localtime
+                type: File
+              name: etc-localtime-host-1
+            - hostPath:
+                path: /run/dbus
+                type: Directory
+              name: run-dbus-host-2
+        '';
+
+        systemd.user.services."podservices-homeassistant" = {
+          Unit.Description = "Home Assistant pod (podman kube)";
+          Unit.After = [ "network-online.target" ];
+          Service = {
+            Type = "simple";
+            ExecStart = "${lib.getExe pkgs.podman} kube play --replace ${config.home.homeDirectory}/services/pod.yaml";
+            ExecStop = "${lib.getExe pkgs.podman} kube down --force ${config.home.homeDirectory}/services/pod.yaml";
+            Restart = "always";
+            RestartSec = "10s";
+          };
+          Install.WantedBy = [ "default.target" ];
+        };
+      };
+  };
+
+  den.hosts.aarch64-linux.pi.users.repparw = {
+    aspect = den.aspects.pi-repparw;
+  };
+}

--- a/modules/hosts/pi.nix
+++ b/modules/hosts/pi.nix
@@ -64,6 +64,11 @@
 
         swapDevices = [ ];
 
+        # Rootless podman's rootlessport must bind host port 80 for the HA pod
+        # (hostPort: 80 below). Debian allowed this via ip_unprivileged_port_start=80;
+        # NixOS defaults to 1024, which would make the bind fail.
+        boot.kernel.sysctl."net.ipv4.ip_unprivileged_port_start" = 80;
+
         hardware.bluetooth.enable = true;
 
         virtualisation.podman = {

--- a/modules/hosts/pi.nix
+++ b/modules/hosts/pi.nix
@@ -1,10 +1,16 @@
 {
   den,
+  inputs,
   lib,
   pkgs,
   ...
 }:
 {
+  flake-file.inputs.disko = {
+    url = "github:nix-community/disko";
+    inputs.nixpkgs.follows = "nixpkgs";
+  };
+
   den.aspects.pi = {
     includes = [
       den.batteries.hostname
@@ -19,7 +25,105 @@
         pkgs,
         ...
       }:
+      let
+        # RPi5 config.txt, mirroring nixpkgs' sd-image-aarch64. u-boot is the
+        # first-stage bootloader; it then reads extlinux from the ext4 root.
+        # [pi5] disables the UART so ghost inputs can't interrupt u-boot
+        # (https://bugzilla.opensuse.org/show_bug.cgi?id=1251192).
+        configTxt = pkgs.writeText "config.txt" ''
+          kernel=u-boot.bin
+
+          # Boot in 64-bit mode.
+          arm_64bit=1
+
+          # U-Boot needs this to work, regardless of whether UART is actually used or not.
+          enable_uart=1
+
+          # Prevent the firmware from smashing the framebuffer setup done by the mainline kernel
+          avoid_warnings=1
+
+          [pi3]
+          # Otherwise the serial output will be garbled.
+          core_freq=250
+
+          [pi4]
+          enable_gic=1
+          armstub=armstub8-gic.bin
+
+          # Otherwise the resolution will be weird in most cases
+          disable_overscan=1
+
+          # Supported in newer board revisions
+          arm_boost=1
+
+          [cm4]
+          # Enable host mode on the 2711 built-in XHCI USB controller.
+          otg_mode=1
+
+          [cm5]
+          dtoverlay=dwc2,dr_mode=host
+
+          [pi5]
+          # On some revisions of the RPi5, U-Boot picks up ghost inputs from the
+          # uart, interrupting the boot process.
+          enable_uart=0
+        '';
+      in
       {
+        imports = [
+          inputs.disko.nixosModules.disko
+        ];
+
+        # SD card layout managed by disko (only /dev/mmcblk0; the NVMe
+        # /home/repparw disk is deliberately NOT listed here, so nixos-anywhere
+        # never formats it). GPT with pinned partition GUIDs so the
+        # by-partuuid mounts below stay valid across installs. enableConfig is
+        # off: the fileSystems below are hand-written on purpose.
+        disko = {
+          enableConfig = false;
+          devices.disk.sd = {
+            type = "disk";
+            device = "/dev/mmcblk0";
+            content = {
+              type = "gpt";
+              partitions = {
+                firmware = {
+                  size = "512M";
+                  type = "EF00";
+                  uuid = "73ede3db-c84d-4604-895a-f18089cbc48e";
+                  content = {
+                    type = "filesystem";
+                    format = "vfat";
+                    mountpoint = "/boot/firmware";
+                    # Replicates nixpkgs' sd-image-aarch64 firmware partition:
+                    # RPi firmware blobs + device trees + u-boot + config.txt
+                    # (kernel=u-boot.bin). Runs on the installer at /mnt.
+                    # Note: no start*.elf in the current raspberrypifw package;
+                    # the RPi5 EEPROM bootloader loads u-boot.bin directly.
+                    postMountHook = ''
+                      cp ${pkgs.raspberrypifw}/share/raspberrypi/boot/bootcode.bin ${pkgs.raspberrypifw}/share/raspberrypi/boot/fixup*.dat /mnt/boot/firmware/
+                      cp ${pkgs.raspberrypifw}/share/raspberrypi/boot/bcm2712*.dtb /mnt/boot/firmware/
+                      cp ${pkgs.ubootRaspberryPiAarch64}/u-boot.bin /mnt/boot/firmware/
+                      cp ${pkgs.raspberrypi-armstubs}/armstub8-gic.bin /mnt/boot/firmware/
+                      cp ${configTxt} /mnt/boot/firmware/config.txt
+                    '';
+                  };
+                };
+                root = {
+                  size = "100%";
+                  type = "8300";
+                  uuid = "b7317088-8461-46c5-9458-a5789a071498";
+                  content = {
+                    type = "filesystem";
+                    format = "ext4";
+                    mountpoint = "/";
+                  };
+                };
+              };
+            };
+          };
+        };
+
         # Raspberry Pi 5 (aarch64) triple-boot loader: firmware (u-boot +
         # config.txt) lives on the vfat /boot/firmware partition, while NixOS
         # writes the extlinux boot files into /boot on the ext4 root.
@@ -37,7 +141,7 @@
 
         fileSystems = {
           "/" = {
-            device = "/dev/disk/by-partuuid/b50071b8-02";
+            device = "/dev/disk/by-partuuid/b7317088-8461-46c5-9458-a5789a071498";
             fsType = "ext4";
             options = [
               "defaults"
@@ -46,7 +150,7 @@
           };
 
           "/boot/firmware" = {
-            device = "/dev/disk/by-partuuid/b50071b8-01";
+            device = "/dev/disk/by-partuuid/73ede3db-c84d-4604-895a-f18089cbc48e";
             fsType = "vfat";
           };
 

--- a/secrets/nix.sops.yaml
+++ b/secrets/nix.sops.yaml
@@ -3,22 +3,31 @@ sops:
     age:
         - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA1UEJ6YnRYYW5JY3BqVURJ
-            dzFQZHE5Q2JkS3pTV1RNcU9rcnBtWFpTSm5FClFtVVo3bkhTN2h4V21NdXdic0Zj
-            Y1FSRHZEb1IyV05WQzU3RW9tOG1ZbmsKLS0tIDNLaG1JbmQ5MTBHWFVsRDEvdVo0
-            c3YwdUlORlZkbXk3RkFrY0lYRnY4N1EKvjCPHMe9DQCKs93VqcZLQPGLyOkS4myk
-            MVT/ESuGXymqOvbOQDiBAT3mBS+Cw8Wg7qIA0Pmio3PwVWJE7tdm/Q==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBiWXZ1V01nQm5ldTJKQmpp
+            QVYrRStwcVdTcko0b2djUGZoVkUyREYyWVM4Cnp6Y1NYTDU2bmVMZ09WSGNSVmNR
+            WG5yUjVYbkUxTlB0dmhYTFBHOWdXeEkKLS0tIDcxYmRITUlvTXRzZlptbFZnOUVT
+            M2hRejBaZy85T05sZ3E4QW1NU0NsNjgKGdtw4b2Q5craOsz7cf1d8Zy7w/IgUg+j
+            Y07EkjFF1EeJbS/rQ3NypWA+9upFo3LBPWiFjKvVHc4MfnjNoyvSmw==
             -----END AGE ENCRYPTED FILE-----
           recipient: age19wxpznth9v4qc46lzzvall6xmazexykkz59ax6w0n4nrgpkcrassld7n3v
         - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAzcFFKeFhIL2pZdG1RaUJM
-            cHFrNXVCSDl5aTBGeEd6R0l4UGhSM2hOMDJ3ClpTRm5rcURFSCt3NHI1VytleWJQ
-            L3d4Y2tOelo5UmFVNDdBbXJiVSsxMFEKLS0tIC9FYU1FUC91bXBvWS93THlHczhS
-            NkxDelRtckZIR2tPazh6VDdKc2NoNTAKRN286aAqu3YEPkgnFtY/fMfDdNA1eLPH
-            BYKo8wA4TvARqeXWZVG8r0R2lqCuF9YUL8yVoA1AXHTLdmxFHOqtPg==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBUMy9rQ05ZampxRk9LN255
+            azd2cEJ3dXRJMWxqakJiQ1FCcmhLSVQ4Vmw0CjRqeUlMMnlXT2sxRW9RaXFxUktv
+            VzhjQVRJcnJNQnp0T0crcHlwQVprNmsKLS0tIGVMb25rQ21vTkdYaXF1MWFNQk13
+            T3dpQUZ4TGJxUDFidWpycS9hNHBsVkUKOTXn06IdPHrUZnUatB+uM/4X+b8M5ZHr
+            aHqZHZ2BnQCJ2dQ83X1Ts4aQWPMQGklg/D+h74QHOfS6c//wMxgZRw==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1jsdf5x72y30aq0ghpuwyn9nv6w7m2jgh3f309kpqaf0jw0d4mgrscefqfp
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA2c2dIMFNHSHU5ZFQ2aWg2
+            emo4U0NEMmdvWXc2MXR6N1JuWFdFNkgwOWgwCkU4NEt5K2ljeW5YaTJER0gxdmpZ
+            OWxHN2txa3pVbEZlSzNaNmJRTFEvSFkKLS0tIEFzWVoxR2VoWXhvTlE3WnN5bUVn
+            eHU0TUNjd1piTml5MkZqT2ltYi9rSzAKSK+kC4zQ/WIwCKfYQNx126F/9skELnJD
+            zubM0D0AV9Jm6JnS57/Xgi82OGPqUlc1+H48FK50P8QQzp47DHk5pw==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1x7qu0en7rg0qm6rq5dfvyn3w34se2qt6wdw7yzgtwjkgj3skssgqmeut5m
     lastmodified: "2026-07-12T21:11:51Z"
     mac: ENC[AES256_GCM,data:vkCUYctXo8m8Nla7VXSoMKTmXleReZcwF4GS9YqmHH7802/M7CsQ09tIFx6Bmjv1qhCEB4zknMugiAIm6lN5e4kCua20bwSg/AxdFE5zUmi4nRZCl5WVT9LP6IIonm8vRNueyM5BRS4VGeD9Al7fdNeWiyoFLTCkZPArTZrBtHM=,iv:zORMYu4iPbPtvcnyS8styyA5l50Ambgre+xBsDQN6Lo=,tag:U9XDAX9KIq1m1+/kXkeP/g==,type:str]
     unencrypted_suffix: _unencrypted


### PR DESCRIPTION
Migrates the RPi5 (192.168.0.4) from Debian 13 to NixOS.

- `den.aspects.pi` host aspect: extlinux boot, podman (rootless, quadlet HA pod on :80), static networking, DoT resolver
- `den.aspects.pi-repparw` minimal headless user aspect (fish, ssh, git, tmux)
- sops: pi age recipient added, `secrets/nix.sops.yaml` re-encrypted

cloudflared was investigated and found orphaned (stale tunnel token, not serving `home.repparw.com` — that's proxied DNS + router port-forward); issue #35 closed wontfix.